### PR TITLE
Add section for ignoring GitHub Actions tasks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,5 @@ This template uses [Azure Key Vault](https://docs.microsoft.com/azure/key-vault/
 ## Reporting Issues and Feedback
 
 If you have any feature requests, issues, or areas for improvement, please [file an issue](https://aka.ms/azure-dev/issues). To keep up-to-date, ask questions, or share suggestions, join our [GitHub Discussions](https://aka.ms/azure-dev/discussions). You may also contact us via AzDevTeam@microsoft.com.
+
+## Teste - Ignorando execução/tarefas github actions


### PR DESCRIPTION
This PR introduces a new section in the README that explains how to ignore GitHub Actions tasks. This addition aims to provide clarity for users regarding task execution management.